### PR TITLE
Updates to the introduction

### DIFF
--- a/draft-ietf-spring-srv6-security.md
+++ b/draft-ietf-spring-srv6-security.md
@@ -107,9 +107,9 @@ new header there are security considerations which must be noted or addressed in
 Specifically, some primary properties of SRv6 that affect the security considerations are:
 
    *  SRv6 may use the SRH which is a type of Routing Extension Header defined by [RFC8754].
-      Some security considerations of the SRH are discussed in [RFC5095] section 5 and [RFC8754] section 7.
+      Some security considerations of the Routing Header, and specifically the SRH, are discussed in [RFC5095] section 5 and [RFC8754] section 7.
 
-   *  SRv6 uses the IPv6 data-plane, and therefore known security considerations of IPv6 [RFC9099] are applicable to SRv6 as well.
+   *  SRv6 uses the IPv6 data-plane, and therefore known security considerations of IPv6 are applicable to SRv6 as well. Some of these considerations are discussed in Section 10 of [RFC8200] and in [RFC9099].
 
    *  While SRv6 uses what appear to be typical IPv6 addresses, the address space is processed differently by segment endpoints.
       A typical IPv6 unicast address is composed of a network prefix, host identifier, and a subnet mask.


### PR DESCRIPTION
Based on the following comments from Alvaro:

...
137        *  SRv6 makes use of the SRH which is a new type of Routing
Extension
138           Header.  Some of the security considerations of the SRH are
139           discussed in [RFC5095] and [RFC8754].

[] The SRH is specified in RFC8754.  To be strict, RFC5095 doesn't talk about the SRH.  RFC8754 already refers to RFC5095 in its Security Considerations.

141        *  SRv6 consists of using the SRH on the IPv6 dataplane, and
142           therefore known security considerations of IPv6 [RFC9099] are
143           applicable to SRv6 as well.

[] Please also point to the Security Considerations in rfc8200.